### PR TITLE
USB Connectivity

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -17,7 +17,8 @@
         android:theme="@android:style/Theme.Holo" >
         <activity
             android:name=".MainActivity"
-            android:label="@string/title_activity_main" android:screenOrientation="landscape">
+            android:label="@string/title_activity_main" android:screenOrientation="landscape"
+            android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,6 +23,12 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            
+            <intent-filter>
+		    	<action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+		    </intent-filter>		
+            
+			<meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" android:resource="@xml/device_filter" />
         </activity>
         <activity android:name=".preferences.AdaptivePreferences" android:screenOrientation="landscape" android:theme="@android:style/Theme.Holo"></activity>
     </application>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-Copyright 2012 Shell M. Shrader
+Copyright 2012 Shell M. Shrader, Evan H. Dekker
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/res/xml/device_filter.xml
+++ b/res/xml/device_filter.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Adaptronic Select e420d Basic -->
+	<usb-device vendor-id="4292" product-id="34189" />  
+</resources>

--- a/src/com/shellware/adaptronic/adaptive/tuner/MainActivity.java
+++ b/src/com/shellware/adaptronic/adaptive/tuner/MainActivity.java
@@ -83,10 +83,8 @@ import com.steema.teechart.tools.Rotate;
 public class MainActivity extends Activity implements ActionBar.TabListener {
 	
 	public static final String TAG = "Adaptive";
-//EVAN
-	//public static final boolean DEBUG_MODE = false;
-	public static final boolean DEBUG_MODE = true;
-//END EVAN
+	public static final boolean DEBUG_MODE = false;
+	
 	public static final short CONNECTION_ERROR = 1;
 	public static final short DATA_READY = 2;
 	public static final short CONNECTED = 3;

--- a/src/com/shellware/adaptronic/adaptive/tuner/MainActivity.java
+++ b/src/com/shellware/adaptronic/adaptive/tuner/MainActivity.java
@@ -41,6 +41,7 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.graphics.Color;
 import android.graphics.PixelFormat;
+import android.hardware.usb.UsbManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
@@ -69,6 +70,7 @@ import com.shellware.adaptronic.adaptive.tuner.changelog.ChangeLog;
 import com.shellware.adaptronic.adaptive.tuner.gauges.GaugeNeedle;
 import com.shellware.adaptronic.adaptive.tuner.modbus.ModbusRTU;
 import com.shellware.adaptronic.adaptive.tuner.preferences.AdaptivePreferences;
+import com.shellware.adaptronic.adaptive.tuner.usb.UsbConnectedThread;
 import com.shellware.adaptronic.adaptive.tuner.valueobjects.LogItems;
 import com.shellware.adaptronic.adaptive.tuner.valueobjects.LogItems.LogItem;
 import com.steema.teechart.TChart;
@@ -81,8 +83,10 @@ import com.steema.teechart.tools.Rotate;
 public class MainActivity extends Activity implements ActionBar.TabListener {
 	
 	public static final String TAG = "Adaptive";
-	public static final boolean DEBUG_MODE = false;
-	
+//EVAN
+	//public static final boolean DEBUG_MODE = false;
+	public static final boolean DEBUG_MODE = true;
+//END EVAN
 	public static final short CONNECTION_ERROR = 1;
 	public static final short DATA_READY = 2;
 	public static final short CONNECTED = 3;
@@ -389,6 +393,16 @@ public class MainActivity extends Activity implements ActionBar.TabListener {
     	
     	ActionBar bar = getActionBar();
     	bar.selectTab(bar.getTabAt(prefs.getInt("prefs_last_tab", 1)));    
+ 
+//EVAN    	
+        String action = getIntent().getAction();
+
+        if (Intent.ACTION_MAIN.equals(action) || UsbManager.ACTION_USB_DEVICE_ATTACHED.equals(action)) { 
+        	if (DEBUG_MODE) Log.d(TAG, "USB Device Attached");
+        	        	
+        	connected = UsbConnectedThread.checkConnectedUsbDevice(this, connectionHandler);
+        }
+//END EVAN    	
     	
     	if (connected != null && connected.isAlive()) {
     		refreshHandler.postDelayed(RefreshRunnable, LONG_PAUSE);

--- a/src/com/shellware/adaptronic/adaptive/tuner/bluetooth/ConnectedThread.java
+++ b/src/com/shellware/adaptronic/adaptive/tuner/bluetooth/ConnectedThread.java
@@ -35,7 +35,10 @@ public class ConnectedThread extends Thread {
     private InputStream mmInStream;
     private OutputStream mmOutStream;
     
-	private final Handler handler;
+//EVAN    
+//	private final Handler handler;
+	protected final Handler handler;
+//END EVAN
 	
 	private String name;
 	

--- a/src/com/shellware/adaptronic/adaptive/tuner/usb/UsbConnectedThread.java
+++ b/src/com/shellware/adaptronic/adaptive/tuner/usb/UsbConnectedThread.java
@@ -1,0 +1,218 @@
+/*
+ *   Copyright 2012 Evan H. Dekker
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *
+ *
+ * ----------------------------------------------------------------------
+ * 
+ * USB API COMPATABILITY NOTE:
+ * Tested on Acer A500 with Android 4.0.3
+ * 
+ * Not all Android devices that claim to support the USB Host API introduced
+ * in Android 3.1 actually do.
+ * 
+ * For a guide, please see this list: http://usbhost.chainfire.eu/
+ * If your device is not listed, please try this app: https://play.google.com/store/apps/details?id=eu.chainfire.usbhostdiagnostics
+ * 
+ * (Author has no affiliation with this service or app)
+ *
+ */
+package com.shellware.adaptronic.adaptive.tuner.usb;
+
+import java.util.HashMap;
+import java.util.Iterator;
+
+import android.content.Context;
+import android.hardware.usb.UsbConstants;
+import android.hardware.usb.UsbDevice;
+import android.hardware.usb.UsbDeviceConnection;
+import android.hardware.usb.UsbEndpoint;
+import android.hardware.usb.UsbInterface;
+import android.hardware.usb.UsbManager;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
+import android.util.Log;
+
+import com.shellware.adaptronic.adaptive.tuner.MainActivity;
+import com.shellware.adaptronic.adaptive.tuner.bluetooth.ConnectedThread;
+
+public class UsbConnectedThread extends ConnectedThread {
+	public static final int USB_VENDOR_ID 	= 0;
+	public static final int USB_PRODUCT_ID 	= 1;
+	
+	//Known ECUs
+	public static final int[][] ADAPTRONIC_USB_ECUS = new int[][] {
+		//Format: {USB_VENDOR_ID, USB_PRODUCT_ID}
+		new int[] {0x10C4, 0x858D} //Select ECU
+	};
+	
+	private static UsbManager mUsbManager = null;
+	
+	private UsbDevice mUsbDevice = null;
+	private UsbDeviceConnection mConnection = null;
+	private UsbEndpoint mInEndpoint = null;
+	private UsbEndpoint mOutEndpoint = null;
+	
+	public UsbConnectedThread(Handler handler, UsbDevice device, UsbDeviceConnection connection, UsbEndpoint inEndpoint, UsbEndpoint outEndpoint) {
+		super(handler);
+		
+		mUsbDevice = device;
+		mConnection = connection;
+		mInEndpoint = inEndpoint;
+		mOutEndpoint = outEndpoint;
+		
+		if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "UsbConnectedThread created");
+		
+		start();
+	}
+
+	public static UsbConnectedThread checkConnectedUsbDevice(Context context, Handler handler) {
+		if (mUsbManager == null) {
+			mUsbManager = (UsbManager)context.getSystemService(Context.USB_SERVICE);
+		}
+		
+		if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "Checking for connected USB devices");
+		
+    	HashMap<String, UsbDevice> deviceList = mUsbManager.getDeviceList();
+    	Iterator<UsbDevice> deviceIterator = deviceList.values().iterator();
+    	
+    	while (deviceIterator.hasNext()) {
+			UsbDevice device = deviceIterator.next();
+			
+			if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "Found USB device");
+			
+			try {
+				boolean deviceReconised = false;
+				
+				for (int[] deviceVendorProductID : ADAPTRONIC_USB_ECUS) {
+					if (device.getVendorId() == deviceVendorProductID[USB_VENDOR_ID] && device.getProductId() == deviceVendorProductID[USB_PRODUCT_ID]) {
+						deviceReconised = true;
+					}
+				}
+			
+				if (deviceReconised) {
+					if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "Adaptronic ECU recognised");									
+					
+					UsbDeviceConnection connection = mUsbManager.openDevice(device);
+					
+					if (!connection.claimInterface(device.getInterface(0), true)) {
+						connectionError(device.getDeviceName(), "Could not claim device interface", handler);
+						return null;
+					}
+					
+					//Control codes for Silicon Labs CP201x USB to UART @ 250000 baud
+					connection.controlTransfer(0x40, 0x00, 0xff, 0xff, null, 0, 0);
+					connection.controlTransfer(0x40, 0x01, 0x00, 0x02, null, 0, 0);
+					connection.controlTransfer(0x40, 0x01, 0x0f, 0x00, null, 0, 0);
+					
+					UsbEndpoint inEndpoint = null;
+					UsbEndpoint outEndpoint = null;
+					
+					for (int interfaceIndex = 0; interfaceIndex < device.getInterfaceCount(); interfaceIndex++) {
+						UsbInterface usbInterface = device.getInterface(interfaceIndex);
+						
+						for (int index = 0; index < usbInterface.getEndpointCount(); index++) {				
+							UsbEndpoint endpoint = usbInterface.getEndpoint(index);
+							
+							if (endpoint.getType() == UsbConstants.USB_ENDPOINT_XFER_BULK) {
+								if (endpoint.getDirection() == UsbConstants.USB_DIR_IN) {
+									if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "In Endpoint Found");	
+									inEndpoint = endpoint;
+								} else if (endpoint.getDirection() == UsbConstants.USB_DIR_OUT) {
+									if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "Out Endpoint Found");
+									outEndpoint = endpoint;
+								}
+							}
+						}
+						
+						if (inEndpoint != null && outEndpoint != null) {
+							return new UsbConnectedThread(handler, device, connection, inEndpoint, outEndpoint);
+						}
+					}
+				}
+			} catch (Exception ex) {
+				connectionError(device.getDeviceName(), ex.getMessage(), handler);
+				return null;
+			}
+    	}
+		
+		return null;
+	}
+	
+	public void run() {
+		byte[] buffer = new byte[512];
+		int bytes;
+		
+		while (true) {
+			bytes = mConnection.bulkTransfer(mInEndpoint, buffer, buffer.length, 5);
+			
+			if (bytes == -1) {
+				if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "Bulk Transfer In Error");
+			} else {
+		        if (MainActivity.DEBUG_MODE)  {
+	                Log.d(MainActivity.TAG, String.format("Received %d bytes", bytes));
+	                
+//			        for (int x = 0; x < bytes; x++) {
+//			        	Log.d(MainActivity.TAG, String.format("%X", buffer[x]));
+//			        }
+		        }
+                
+                // Send the obtained bytes to the UI activity
+		        Bundle b = new Bundle();
+
+		        b.putShort("handle", MainActivity.DATA_READY);
+		        b.putByteArray("data", buffer);
+		        b.putInt("length", bytes);
+		        
+		        Message msg = new Message();
+		        msg.setData(b);
+		        
+		        handler.sendMessage(msg);
+			}
+			
+			try {
+				Thread.sleep(5);
+			} catch (Exception e) {}
+	
+		}		
+	}
+	
+	public void write(byte[] bytes) {
+		if (mConnection.bulkTransfer(mOutEndpoint, bytes, bytes.length, 5) == -1) {
+			if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "Bulk Transfer Out Error");
+		}
+	}
+	
+	public void cancel() {
+		mConnection.close();
+	}
+	
+	private static void connectionError(String name, String message, Handler handler) {
+ //   	if (disconnecting) break;
+
+        Bundle b = new Bundle();
+        
+        b.putShort("handle", MainActivity.CONNECTION_ERROR);
+        b.putString("title", name);
+        b.putString("message", message);
+        
+        Message msg = new Message();
+        msg.setData(b);
+        
+        if (MainActivity.DEBUG_MODE) Log.d(MainActivity.TAG, "Connection error - " + message); 
+        handler.sendMessage(msg);
+	}
+}


### PR DESCRIPTION
Implements direct USB connectivity from Android 3.1+ devices to Adaptronic ECUs using standard USB cable. Currently only known USB vendor and product IDs is for Adaptronic Select ECUs. (tested with e420d).

Please also read note in com.shellware.adaptronic.adaptive.tuner.usb.UsbConnectedThread comment header regarding device compatibility. Generally speaking, all new devices appear to support the API fully and would be plug-and-play. The period between 3.1 and 4.0 saw these compatibility inconsistencies.
